### PR TITLE
add duration to playlist

### DIFF
--- a/lib/m3u8/playlist.rb
+++ b/lib/m3u8/playlist.rb
@@ -38,6 +38,16 @@ module M3u8
       true
     end
 
+    def duration
+      duration = 0.0
+      items.each do |item|
+        if item.is_a?(M3u8::SegmentItem)
+          duration += item.duration
+        end
+      end
+      duration
+    end
+
     private
 
     def assign_options(options)

--- a/spec/playlist_spec.rb
+++ b/spec/playlist_spec.rb
@@ -194,4 +194,20 @@ describe M3u8::Playlist do
     expect(playlist.master?).to be true
     expect(playlist.items.size).to eq 6
   end
+
+  it 'should return the total duration of a playlist' do
+    playlist = M3u8::Playlist.new
+
+
+    item = M3u8::SegmentItem.new({ duration: 10.991, segment: 'test_01.ts' })
+    playlist.items.push item
+    item = M3u8::SegmentItem.new({ duration: 9.891, segment: 'test_02.ts' })
+    playlist.items.push item
+    item = M3u8::SegmentItem.new({ duration: 10.556, segment: 'test_03.ts' })
+    playlist.items.push item
+    item = M3u8::SegmentItem.new({ duration: 8.790, segment: 'test_04.ts' })
+    playlist.items.push item
+
+    expect(playlist.duration.round(3)).to eq 40.228
+  end
 end


### PR DESCRIPTION
This patch allows one to call duration on the playlist to get the total reported duration