### PR TITLE
Omit "PROGRAM-ID=..." if `program_id` not provided.

### DIFF
--- a/lib/m3u8/playlist_item.rb
+++ b/lib/m3u8/playlist_item.rb
@@ -34,8 +34,12 @@ module M3u8
 
     def to_s
       validate
-      "#EXT-X-STREAM-INF:PROGRAM-ID=#{program_id},#{resolution_format}" +
-        %(CODECS="#{codecs}",BANDWIDTH=#{bitrate}\n#{playlist})
+
+      str = "#EXT-X-STREAM-INF:"
+      str += [program_id_format, resolution_format, codecs_format, bandwidth_format].compact.join(',')
+      str += "\n#{playlist}"
+
+      return str
     end
 
     private
@@ -44,9 +48,22 @@ module M3u8
       fail MissingCodecError, MISSING_CODEC_MESSAGE if codecs.nil?
     end
 
+    def program_id_format
+      return if program_id.nil?
+      "PROGRAM-ID=#{program_id}"
+    end
+
     def resolution_format
       return if resolution.nil?
-      "RESOLUTION=#{resolution},"
+      "RESOLUTION=#{resolution}"
+    end
+
+    def codecs_format
+      "CODECS=\"#{codecs}\""
+    end
+
+    def bandwidth_format
+      "BANDWIDTH=#{bitrate}"
     end
 
     def audio_codec(audio)

--- a/spec/playlist_spec.rb
+++ b/spec/playlist_spec.rb
@@ -8,6 +8,17 @@ describe M3u8::Playlist do
   end
 
   it 'should render master playlist' do
+    options = { playlist: 'playlist_url', bitrate: 6400,
+                audio: 'mp3' }
+    item = M3u8::PlaylistItem.new options
+    playlist = M3u8::Playlist.new
+    playlist.items.push item
+
+    output = "#EXTM3U\n" +
+             %(#EXT-X-STREAM-INF:CODECS="mp4a.40.34") +
+             ",BANDWIDTH=6400\nplaylist_url\n"
+    expect(playlist.to_s).to eq output
+
     options = { program_id: '1', playlist: 'playlist_url', bitrate: 6400,
                 audio: 'mp3' }
     item = M3u8::PlaylistItem.new options

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -2,6 +2,21 @@ require 'spec_helper'
 
 describe M3u8::Writer do
   it 'should render master playlist' do
+    options = { playlist: 'playlist_url', bitrate: 6400,
+                audio: 'mp3' }
+    item = M3u8::PlaylistItem.new options
+    playlist = M3u8::Playlist.new
+    playlist.items.push item
+
+    output = "#EXTM3U\n" +
+             %(#EXT-X-STREAM-INF:CODECS="mp4a.40.34") +
+             ",BANDWIDTH=6400\nplaylist_url\n"
+
+    io = StringIO.open
+    writer = M3u8::Writer.new io
+    writer.write playlist
+    expect(io.string).to eq output
+
     options = { program_id: '1', playlist: 'playlist_url', bitrate: 6400,
                 audio: 'mp3' }
     item = M3u8::PlaylistItem.new options


### PR DESCRIPTION
I was getting a deprecation warning with the latest `mediastreamvalidator` – apparently the `PROGRAM-ID` option is now deprecated for master playlists.