### PR TITLE
Fix codec string for H.264 High Level 4.1

### DIFF
--- a/lib/m3u8/playlist_item.rb
+++ b/lib/m3u8/playlist_item.rb
@@ -155,8 +155,8 @@ module M3u8
       return 'avc1.4d001f' if profile == 'main' && level == 3.1
       return 'avc1.4d0028' if profile == 'main' && level == 4.0
       return 'avc1.64001f' if profile == 'high' && level == 3.1
-      return 'avc1.640028' if profile == 'high' &&
-                              (level == 4.0 || level == 4.1)
+      return 'avc1.640028' if profile == 'high' && level == 4.0
+      return 'avc1.640029' if profile == 'high' && level == 4.1
     end
   end
 end

--- a/spec/lib/m3u8/playlist_item_spec.rb
+++ b/spec/lib/m3u8/playlist_item_spec.rb
@@ -162,7 +162,7 @@ describe M3u8::PlaylistItem do
 
     options = { profile: 'high', level: 4.1 }
     item = M3u8::PlaylistItem.new options
-    expect(item.codecs).to eq 'avc1.640028'
+    expect(item.codecs).to eq 'avc1.640029'
   end
 
   it 'should raise error if codecs are missing' do

--- a/spec/lib/m3u8/playlist_spec.rb
+++ b/spec/lib/m3u8/playlist_spec.rb
@@ -39,7 +39,7 @@ describe M3u8::Playlist do
 
     output = "#EXTM3U\n" \
              '#EXT-X-STREAM-INF:PROGRAM-ID=2,RESOLUTION=1920x1080,' +
-             %(CODECS="avc1.640028,mp4a.40.2",BANDWIDTH=50000\n) +
+             %(CODECS="avc1.640029,mp4a.40.2",BANDWIDTH=50000\n) +
              "playlist_url\n"
 
     expect(playlist.to_s).to eq output
@@ -58,7 +58,7 @@ describe M3u8::Playlist do
     output = "#EXTM3U\n" +
              %(#EXT-X-STREAM-INF:PROGRAM-ID=1,CODECS="mp4a.40.34") +
              ",BANDWIDTH=6400\nplaylist_url\n#EXT-X-STREAM-INF:PROGRAM-ID=2," +
-             %(RESOLUTION=1920x1080,CODECS="avc1.640028,mp4a.40.2") +
+             %(RESOLUTION=1920x1080,CODECS="avc1.640029,mp4a.40.2") +
              ",BANDWIDTH=50000\nplaylist_url\n"
     expect(playlist.to_s).to eq output
   end

--- a/spec/lib/m3u8/writer_spec.rb
+++ b/spec/lib/m3u8/writer_spec.rb
@@ -41,7 +41,7 @@ describe M3u8::Writer do
 
     output = "#EXTM3U\n" \
              '#EXT-X-STREAM-INF:PROGRAM-ID=2,RESOLUTION=1920x1080,' +
-             %(CODECS="avc1.640028,mp4a.40.2",BANDWIDTH=50000\n) +
+             %(CODECS="avc1.640029,mp4a.40.2",BANDWIDTH=50000\n) +
              "playlist_url\n"
 
     io = StringIO.open
@@ -67,7 +67,7 @@ describe M3u8::Writer do
     output = "#EXTM3U\n" +
              %(#EXT-X-STREAM-INF:PROGRAM-ID=1,CODECS="mp4a.40.34") +
              ",BANDWIDTH=6400\nplaylist_url\n#EXT-X-STREAM-INF:PROGRAM-ID=2," +
-             %(RESOLUTION=1920x1080,CODECS="avc1.640028,mp4a.40.2") +
+             %(RESOLUTION=1920x1080,CODECS="avc1.640029,mp4a.40.2") +
              ",BANDWIDTH=50000\nplaylist_url\n" +
              %(#EXT-X-SESSION-DATA:DATA-ID="com.test.movie.title",) +
              %(VALUE="Test",URI="http://test",LANGUAGE="en"\n)


### PR DESCRIPTION
H.264 High Level 4.1 should be avc1.640029 instead of avc1.640028.

Here's the Google docs on the subject: https://developers.google.com/cast/docs/media

Interestingly enough, the Apple documentation says it should be 28!

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/StreamingMediaGuide/FrequentlyAskedQuestions/FrequentlyAskedQuestions.html

However, the Apple mediastreamvalidator tool reports an error for a 4.1 stream with 28 saying that it expected 29. I think the Apple docs are incorrect, and have submitted a bug report.