### PR TITLE
Defined require order

### DIFF
--- a/lib/m3u8.rb
+++ b/lib/m3u8.rb
@@ -1,5 +1,5 @@
 require 'stringio'
-Dir[File.dirname(__FILE__) + '/m3u8/*.rb'].each { |file| require file }
+Dir[File.dirname(__FILE__) + '/m3u8/*.rb'].sort.each { |file| require file }
 
 # M3u8 provides parsing, generation, and validation of m3u8 playlists
 module M3u8


### PR DESCRIPTION
```
#<NameError: uninitialized constant M3u8::KeyItem::Encryptable>
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8/key_item.rb:4:in `<class:KeyItem>'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8/key_item.rb:3:in `<module:M3u8>'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8/key_item.rb:1:in `<top (required)>'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8.rb:2:in `require'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8.rb:2:in `block in <top (required)>'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8.rb:2:in `each'
/apps/video-processing/vendor/bundle/ruby/2.2.0/gems/m3u8-0.6.2/lib/m3u8.rb:2:in `<top (required)>'
```