### PR TITLE
Add NAME attribute to playlist item

### DIFF
--- a/lib/m3u8/playlist_item.rb
+++ b/lib/m3u8/playlist_item.rb
@@ -6,7 +6,7 @@ module M3u8
     attr_accessor :program_id, :width, :height, :codecs, :bandwidth,
                   :audio_codec, :level, :profile, :video, :audio, :uri,
                   :average_bandwidth, :subtitles, :closed_captions, :iframe,
-                  :frame_rate
+                  :frame_rate, :name
     MISSING_CODEC_MESSAGE = 'Audio or video codec info should be provided.'
 
     def initialize(params = {})
@@ -69,7 +69,8 @@ module M3u8
         frame_rate: parse_frame_rate(attributes['FRAME-RATE']),
         video: attributes['VIDEO'], audio: attributes['AUDIO'],
         uri: attributes['URI'], subtitles: attributes['SUBTITLES'],
-        closed_captions: attributes['CLOSED-CAPTIONS'] }
+        closed_captions: attributes['CLOSED-CAPTIONS'],
+        name: attributes['NAME'] }
     end
 
     def parse_average_bandwidth(value)
@@ -112,7 +113,8 @@ module M3u8
        audio_format,
        video_format,
        subtitles_format,
-       closed_captions_format].compact.join(',')
+       closed_captions_format,
+       name_format].compact.join(',')
     end
 
     def program_id_format
@@ -166,6 +168,11 @@ module M3u8
       else
         %(CLOSED-CAPTIONS="#{closed_captions}")
       end
+    end
+
+    def name_format
+      return if name.nil?
+      %(NAME="#{name}")
     end
 
     def audio_codec

--- a/spec/lib/m3u8/playlist_item_spec.rb
+++ b/spec/lib/m3u8/playlist_item_spec.rb
@@ -20,7 +20,8 @@ describe M3u8::PlaylistItem do
       input = %(#EXT-X-STREAM-INF:CODECS="avc",BANDWIDTH=540,) +
               %(PROGRAM-ID=1,RESOLUTION=1920x1080,FRAME-RATE=23.976,) +
               %(AVERAGE-BANDWIDTH=550,AUDIO="test",VIDEO="test2",) +
-              %(SUBTITLES="subs",CLOSED-CAPTIONS="caps",URI="test.url")
+              %(SUBTITLES="subs",CLOSED-CAPTIONS="caps",URI="test.url",) +
+              %(NAME="1080p")
       item = M3u8::PlaylistItem.parse(input)
       expect(item.program_id).to eq '1'
       expect(item.codecs).to eq 'avc'
@@ -34,12 +35,14 @@ describe M3u8::PlaylistItem do
       expect(item.subtitles).to eq 'subs'
       expect(item.closed_captions).to eq 'caps'
       expect(item.uri).to eq 'test.url'
+      expect(item.name).to eq '1080p'
     end
 
     it 'should parse m3u8 into current instance' do
       input = %(#EXT-X-STREAM-INF:CODECS="avc",BANDWIDTH=540,) +
               %(PROGRAM-ID=1,AUDIO="test",VIDEO="test2",) +
-              %(SUBTITLES="subs",CLOSED-CAPTIONS="caps",URI="test.url")
+              %(SUBTITLES="subs",CLOSED-CAPTIONS="caps",URI="test.url",) +
+              %(NAME="SD")
       item = M3u8::PlaylistItem.new
       item.parse(input)
       expect(item.program_id).to eq '1'
@@ -53,6 +56,7 @@ describe M3u8::PlaylistItem do
       expect(item.subtitles).to eq 'subs'
       expect(item.closed_captions).to eq 'caps'
       expect(item.uri).to eq 'test.url'
+      expect(item.name).to eq 'SD'
     end
   end
 
@@ -75,13 +79,13 @@ describe M3u8::PlaylistItem do
 
     hash = { codecs: 'avc', bandwidth: 540, uri: 'test.url', audio: 'test',
              video: 'test2', average_bandwidth: 500, subtitles: 'subs',
-             frame_rate: 30, closed_captions: 'caps' }
+             frame_rate: 30, closed_captions: 'caps', name: 'SD' }
     item = M3u8::PlaylistItem.new(hash)
     output = item.to_s
     expected = %(#EXT-X-STREAM-INF:CODECS="avc",BANDWIDTH=540,) +
                %(AVERAGE-BANDWIDTH=500,FRAME-RATE=30.000,) +
                %(AUDIO="test",VIDEO="test2",SUBTITLES="subs",) +
-               %(CLOSED-CAPTIONS="caps"\ntest.url)
+               %(CLOSED-CAPTIONS="caps",NAME="SD"\ntest.url)
     expect(output).to eq expected
   end
 


### PR DESCRIPTION
Support non-standard `Name` attribute in playlist item.

This is used by Wowza and JWPlayer to show a quality selector option in the player (see https://support.jwplayer.com/customer/portal/articles/1430240-hls-adaptive-streaming )