### PR TITLE
Always render the duration as a decimal integer.

### DIFF
--- a/lib/m3u8/writer.rb
+++ b/lib/m3u8/writer.rb
@@ -34,11 +34,15 @@ module M3u8
       io.puts '#EXT-X-I-FRAMES-ONLY' if playlist.iframes_only
       io.puts "#EXT-X-MEDIA-SEQUENCE:#{playlist.sequence}"
       io.puts "#EXT-X-ALLOW-CACHE:#{cache(playlist)}"
-      io.puts "#EXT-X-TARGETDURATION:#{playlist.target}"
+      io.puts target_duration_format(playlist)
     end
 
     def cache(playlist)
       playlist.cache ? 'YES' : 'NO'
+    end
+
+    def target_duration_format(playlist)
+      format('#EXT-X-TARGETDURATION:%d', playlist.target)
     end
   end
 end

--- a/spec/lib/m3u8/writer_spec.rb
+++ b/spec/lib/m3u8/writer_spec.rb
@@ -147,6 +147,14 @@ describe M3u8::Writer do
     expect(io.string).to eq output
   end
 
+  it 'should render the target duration as a decimal-integer' do
+    playlist = M3u8::Playlist.new(target: 6.2)
+    io = StringIO.open
+    writer = M3u8::Writer.new io
+    writer.write playlist
+    expect(io.string).to include('#EXT-X-TARGETDURATION:6')
+  end
+
   it 'should raise error on write if item types are mixed' do
     playlist = M3u8::Playlist.new
 


### PR DESCRIPTION
Part of the spec. Safari refuses to play a video with a non-integer target duration.