### PR TITLE
Add basic support for live playlists

### DIFF
--- a/lib/m3u8/playlist.rb
+++ b/lib/m3u8/playlist.rb
@@ -72,7 +72,6 @@ module M3u8
       @independent_segments = options[:independent_segments]
       @master = options[:master]
       @live = options[:live]
-
     end
 
     def defaults

--- a/lib/m3u8/playlist.rb
+++ b/lib/m3u8/playlist.rb
@@ -5,7 +5,7 @@ module M3u8
   class Playlist
     attr_accessor :items, :version, :cache, :target, :sequence,
                   :discontinuity_sequence, :type, :iframes_only,
-                  :independent_segments
+                  :independent_segments, :live
 
     def initialize(options = {})
       assign_options(options)
@@ -25,6 +25,11 @@ module M3u8
     def write(output)
       writer = Writer.new(output)
       writer.write(self)
+    end
+
+    def live?
+      return false if master?
+      @live
     end
 
     def master?
@@ -66,6 +71,8 @@ module M3u8
       @iframes_only = options[:iframes_only]
       @independent_segments = options[:independent_segments]
       @master = options[:master]
+      @live = options[:live]
+
     end
 
     def defaults
@@ -73,7 +80,8 @@ module M3u8
         sequence: 0,
         target: 10,
         iframes_only: false,
-        independent_segments: false
+        independent_segments: false,
+        live: false
       }
     end
 

--- a/lib/m3u8/writer.rb
+++ b/lib/m3u8/writer.rb
@@ -20,7 +20,7 @@ module M3u8
     end
 
     def write_footer(playlist)
-      return if playlist.master?
+      return if playlist.live? || playlist.master?
       io.puts '#EXT-X-ENDLIST'
     end
 

--- a/spec/lib/m3u8/playlist_spec.rb
+++ b/spec/lib/m3u8/playlist_spec.rb
@@ -110,6 +110,43 @@ describe M3u8::Playlist do
     end
   end
 
+  describe '#live?' do
+    context 'when playlist is a master playlist' do
+      it 'returns false' do
+        options = { program_id: '1', uri: 'playlist_url', bandwidth: 6400,
+                    audio_codec: 'mp3' }
+        item = M3u8::PlaylistItem.new(options)
+        playlist.items << item
+
+        expect(playlist.live).to be false
+      end
+    end
+
+    context 'when playlist is a media playlist and set as live' do
+      it 'returns true' do
+        playlist = described_class.new(live: true)
+        item = M3u8::SegmentItem.new(duration: 10.991, segment: 'test_01.ts')
+        playlist.items << item
+        expect(playlist.live?).to be true
+      end
+    end
+
+    context 'when a new playlist is set as not live' do
+      it 'returns false' do
+        playlist = described_class.new(live: false)
+        expect(playlist.live).to be false
+      end
+    end
+
+    context 'when playlist is a new playlist' do
+      it 'returns false' do
+        expect(playlist.live?).to be false
+      end
+    end
+
+
+  end
+
   describe '#to_s' do
     it 'returns master playlist text' do
       options = { program_id: '1', uri: 'playlist_url', bandwidth: 6400,

--- a/spec/lib/m3u8/playlist_spec.rb
+++ b/spec/lib/m3u8/playlist_spec.rb
@@ -143,8 +143,6 @@ describe M3u8::Playlist do
         expect(playlist.live?).to be false
       end
     end
-
-
   end
 
   describe '#to_s' do


### PR DESCRIPTION
Adds a boolean `live` flag to the playlist which will cause the '#EXT-X-ENDLIST' tag to be omitted on write.