### PR TITLE
Do not require codecs for M3u8::PlaylistItem#to_s. Do not include CODECS in EXT-X-STREAM-INF if codec not recognized.

### DIFF
--- a/lib/m3u8/error.rb
+++ b/lib/m3u8/error.rb
@@ -3,9 +3,6 @@ module M3u8
   class InvalidPlaylistError < StandardError
   end
 
-  class MissingCodecError < StandardError
-  end
-
   class PlaylistTypeError < StandardError
   end
 end

--- a/spec/lib/m3u8/playlist_item_spec.rb
+++ b/spec/lib/m3u8/playlist_item_spec.rb
@@ -75,11 +75,74 @@ describe M3u8::PlaylistItem do
 
   describe '#to_s' do
     context 'when codecs is missing' do
-      it 'raises error' do
+      it 'does not specify CODECS' do
         params = { bandwidth: 540, uri: 'test.url' }
         item = M3u8::PlaylistItem.new params
-        message = 'Audio or video codec info should be provided.'
-        expect { item.to_s }.to raise_error(M3u8::MissingCodecError, message)
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when level is not recognized' do
+      it 'does not specify CODECS' do
+        params = { bandwidth: 540, uri: 'test.url', level: 9001 }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when profile is not recognized' do
+      it 'does not specify CODECS' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'best' }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when profile and level are not recognized' do
+      it 'does not specify CODECS' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'best', level: 9001 }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when profile and level are not recognized and audio codec is recognized' do
+      it 'does not specify CODECS' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'best', level: 9001, audio_codec: 'aac-lc' }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when profile and level are recognized and audio codec is not recognized' do
+      it 'does not specify CODECS' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'high', level: 4.1, audio_codec: 'fuzzy' }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).not_to include('CODECS')
+      end
+    end
+
+    context 'when profile and level are not set and audio codec is recognized' do
+      it 'specifies CODECS with audio codec' do
+        params = { bandwidth: 540, uri: 'test.url', audio_codec: 'aac-lc' }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).to include('CODECS="mp4a.40.2"')
+      end
+    end
+
+    context 'when profile and level are recognized and audio codec is not set' do
+      it 'specifies CODECS with video codec' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'high', level: 4.1 }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).to include('CODECS="avc1.640029"')
+      end
+    end
+
+    context 'when profile and level are recognized and audio codec is recognized' do
+      it 'specifies CODECS with video codec and audio_codec' do
+        params = { bandwidth: 540, uri: 'test.url', profile: 'high', level: 4.1, audio_codec: 'aac-lc' }
+        item = M3u8::PlaylistItem.new params
+        expect(item.to_s).to include('CODECS="avc1.640029,mp4a.40.2"')
       end
     end
 


### PR DESCRIPTION
When the video profile is not recognized (e.g. "Constrained Baseline"), `EXT-X-STREAM-INF` will be written with only the audio codec. This causes Android to play only the audio stream and iOS 10 to not play at all (there may be other behaviour on different versions). The HLS spec indicates only that `CODECS` "SHOULD" be included.

This PR makes the following changes to `M3u8::PlaylistItem`:
* no longer enforces non-nil codecs in `to_s`
* does not set CODECS if either video codec string or audio codec string can not be determined from the input (`level`, `profile`, `audio_codec`)
