### PR TITLE
Support more 'high' codec strings

### DIFF
--- a/lib/m3u8/playlist_item.rb
+++ b/lib/m3u8/playlist_item.rb
@@ -207,9 +207,10 @@ module M3u8
     end
 
     def high_codec_string(level)
-      return 'avc1.64001f' if level == 3.1
-      return 'avc1.640028' if level == 4.0
-      return 'avc1.640029' if level == 4.1
+      return nil unless [3.0, 3.1, 3.2, 4.0, 4.1, 4.2, 5.0, 5.1, 5.2].include?(level)
+
+      level_hex_string = level.to_s.sub('.', '').to_i.to_s(16)
+      return "avc1.6400#{level_hex_string}"
     end
   end
 end

--- a/spec/lib/m3u8/playlist_item_spec.rb
+++ b/spec/lib/m3u8/playlist_item_spec.rb
@@ -284,5 +284,9 @@ describe M3u8::PlaylistItem do
     options = { profile: 'high', level: 4.1 }
     item = M3u8::PlaylistItem.new options
     expect(item.codecs).to eq 'avc1.640029'
+
+    options = { profile: 'high', level: 5.1 }
+    item = M3u8::PlaylistItem.new options
+    expect(item.codecs).to eq 'avc1.640033'
   end
 end


### PR DESCRIPTION
Changed the implementation of `high_codec_string` to use a whitelist of accepted levels and convert the level to a hex string.