### PR TITLE
Fix SegmentItem to wrap raw Time in program_date_time

### DIFF
--- a/lib/m3u8/segment_item.rb
+++ b/lib/m3u8/segment_item.rb
@@ -13,8 +13,19 @@ module M3u8
     end
 
     def to_s
-      date = "#{program_date_time}\n" unless program_date_time.nil?
-      "#EXTINF:#{duration},#{comment}#{byterange_format}\n#{date}#{segment}"
+      "#EXTINF:#{duration},#{comment}#{byterange_format}" \
+        "\n#{date_format}#{segment}"
+    end
+
+    def date_format
+      return if program_date_time.nil?
+
+      pdt = if program_date_time.is_a?(TimeItem)
+              program_date_time
+            else
+              TimeItem.new(time: program_date_time)
+            end
+      "#{pdt}\n"
     end
 
     private

--- a/spec/lib/m3u8/segment_item_spec.rb
+++ b/spec/lib/m3u8/segment_item_spec.rb
@@ -54,4 +54,16 @@ describe M3u8::SegmentItem do
     expected = "#EXTINF:10.991,anything\n#EXT-X-BYTERANGE:4500\ntest.ts"
     expect(output).to eq expected
   end
+
+  it 'wraps raw Time in program_date_time as TimeItem' do
+    time = Time.iso8601('2020-11-25T20:27:00Z')
+    hash = { duration: 10, segment: 'segment.aac',
+             program_date_time: time }
+    item = M3u8::SegmentItem.new(hash)
+    output = item.to_s
+    expected = "#EXTINF:10,\n" \
+               "#EXT-X-PROGRAM-DATE-TIME:2020-11-25T20:27:00Z\n" \
+               'segment.aac'
+    expect(output).to eq expected
+  end
 end


### PR DESCRIPTION
Passing a Time object as program_date_time produced bare timestamp output without the #EXT-X-PROGRAM-DATE-TIME tag, causing players to request the timestamp string as a URL. Automatically wrap non-TimeItem values in a TimeItem for correct serialization.

Fixes #29