### PR TITLE
Fix Reader to handle \r and \r\n line endings

### DIFF
--- a/lib/m3u8/reader.rb
+++ b/lib/m3u8/reader.rb
@@ -19,7 +19,8 @@ module M3u8
     def read(input)
       @playlist = Playlist.new
       @has_endlist = false
-      input.each_line.with_index do |line, index|
+      lines = input.is_a?(String) ? input : input.read
+      lines.split(/\r\n|\r|\n/).each_with_index do |line, index|
         validate_file_format(line) if index.zero?
         parse_line(line)
       end
@@ -106,7 +107,7 @@ module M3u8
     end
 
     def parse_playlist_type(line)
-      playlist.type = line.gsub('#EXT-X-PLAYLIST-TYPE:', '').delete!("\n")
+      playlist.type = line.gsub('#EXT-X-PLAYLIST-TYPE:', '').strip
     end
 
     def parse_version(line)

--- a/spec/lib/m3u8/reader_spec.rb
+++ b/spec/lib/m3u8/reader_spec.rb
@@ -552,6 +552,24 @@ describe M3u8::Reader do
       expect(report.last_msn).to eq(101)
     end
 
+    it 'parses playlist with \\r line endings' do
+      text = "#EXTM3U\r" \
+             "#EXT-X-VERSION:4\r" \
+             "#EXT-X-TARGETDURATION:10\r" \
+             "#EXT-X-MEDIA-SEQUENCE:0\r" \
+             "#EXTINF:10.0,\r" \
+             "segment0.ts\r" \
+             "#EXT-X-ENDLIST\r"
+      playlist = reader.read(text)
+      expect(playlist.master?).to be false
+      expect(playlist.version).to eq(4)
+      expect(playlist.items.size).to eq(1)
+
+      item = playlist.items[0]
+      expect(item).to be_a(M3u8::SegmentItem)
+      expect(item.segment).to eq('segment0.ts')
+    end
+
     context 'when playlist source is invalid' do
       it 'raises error with message' do
         message = 'Playlist must start with a #EXTM3U tag, line read ' \


### PR DESCRIPTION
Reader used each_line which only splits on \n, causing \r-only files (e.g. iTunes M3U8 exports) to be seen as a single line. Split on all common line endings (\r\n, \r, \n) instead.

Also fix parse_playlist_type which used delete!("\n") that returns nil when no newline is present after the split change.

Fixes #30