### PR TITLE
Add convenience accessor methods to Playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**1.1.0**
+
+* Added convenience accessor methods to `Playlist` for filtering items by type: `segments`, `playlists`, `media_items`, `keys`, `maps`, `date_ranges`, `parts`, `session_data`.
+
+***
+
 **1.0.0**
 
 * Full HLS spec compliance with draft-pantos-hls-rfc8216bis-19 (Protocol Version 13).

--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ playlist.items.first
 #  => #<M3u8::PlaylistItem ...>
 ```
 
+Convenience methods filter items by type:
+
+```ruby
+playlist.playlists    # => [PlaylistItem, ...]
+playlist.segments     # => [SegmentItem, ...]
+playlist.media_items  # => [MediaItem, ...]
+playlist.keys         # => [KeyItem, ...]
+playlist.maps         # => [MapItem, ...]
+playlist.date_ranges  # => [DateRangeItem, ...]
+playlist.parts        # => [PartItem, ...]
+playlist.session_data # => [SessionDataItem, ...]
+```
+
 Parse an LL-HLS playlist:
 
 ```ruby

--- a/lib/m3u8/playlist.rb
+++ b/lib/m3u8/playlist.rb
@@ -54,12 +54,40 @@ module M3u8
       true
     end
 
+    def segments
+      items.select { |item| item.is_a?(SegmentItem) }
+    end
+
+    def playlists
+      items.select { |item| item.is_a?(PlaylistItem) }
+    end
+
+    def media_items
+      items.select { |item| item.is_a?(MediaItem) }
+    end
+
+    def keys
+      items.select { |item| item.is_a?(KeyItem) }
+    end
+
+    def maps
+      items.select { |item| item.is_a?(MapItem) }
+    end
+
+    def date_ranges
+      items.select { |item| item.is_a?(DateRangeItem) }
+    end
+
+    def parts
+      items.select { |item| item.is_a?(PartItem) }
+    end
+
+    def session_data
+      items.select { |item| item.is_a?(SessionDataItem) }
+    end
+
     def duration
-      duration = 0.0
-      items.each do |item|
-        duration += item.duration if item.is_a?(M3u8::SegmentItem)
-      end
-      duration
+      segments.sum(&:duration)
     end
 
     private
@@ -92,11 +120,11 @@ module M3u8
     end
 
     def playlist_size
-      items.count { |item| item.is_a?(PlaylistItem) }
+      playlists.size
     end
 
     def segment_size
-      items.count { |item| item.is_a?(SegmentItem) }
+      segments.size
     end
   end
 end

--- a/spec/lib/m3u8/playlist_spec.rb
+++ b/spec/lib/m3u8/playlist_spec.rb
@@ -236,6 +236,80 @@ describe M3u8::Playlist do
     end
   end
 
+  describe '#segments' do
+    it 'returns only segment items' do
+      file = File.open('spec/fixtures/playlist.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.segments).to all be_a(M3u8::SegmentItem)
+      expect(playlist.segments.size).to eq(138)
+    end
+  end
+
+  describe '#playlists' do
+    it 'returns only playlist items' do
+      file = File.open('spec/fixtures/master.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.playlists).to all be_a(M3u8::PlaylistItem)
+      expect(playlist.playlists.size).to eq(6)
+    end
+  end
+
+  describe '#media_items' do
+    it 'returns only media items' do
+      file = File.open('spec/fixtures/variant_audio.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.media_items).to all be_a(M3u8::MediaItem)
+      expect(playlist.media_items.size).to eq(6)
+    end
+  end
+
+  describe '#keys' do
+    it 'returns only key items' do
+      file = File.open('spec/fixtures/encrypted.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.keys).to all be_a(M3u8::KeyItem)
+      expect(playlist.keys.size).to eq(2)
+    end
+  end
+
+  describe '#maps' do
+    it 'returns only map items' do
+      file = File.open('spec/fixtures/map_playlist.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.maps).to all be_a(M3u8::MapItem)
+      expect(playlist.maps.size).to eq(1)
+    end
+  end
+
+  describe '#date_ranges' do
+    it 'returns only date range items' do
+      file = File.open('spec/fixtures/daterange_playlist.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.date_ranges)
+        .to all be_a(M3u8::DateRangeItem)
+      expect(playlist.date_ranges.size).to eq(3)
+    end
+  end
+
+  describe '#parts' do
+    it 'returns only part items' do
+      file = File.open('spec/fixtures/ll_hls_playlist.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.parts).to all be_a(M3u8::PartItem)
+      expect(playlist.parts.size).to eq(5)
+    end
+  end
+
+  describe '#session_data' do
+    it 'returns only session data items' do
+      file = File.open('spec/fixtures/session_data.m3u8')
+      playlist = described_class.read(file)
+      expect(playlist.session_data)
+        .to all be_a(M3u8::SessionDataItem)
+      expect(playlist.session_data.size).to eq(3)
+    end
+  end
+
   describe '#write' do
     context 'when playlist is valid' do
       it 'returns playlist text' do


### PR DESCRIPTION
Provide filtered item accessors (segments, playlists, media_items, keys, maps, date_ranges, parts, session_data) so users don't need to manually filter by class. Refactor duration, playlist_size, and segment_size to reuse the new methods.