### PR TITLE
Upgrade version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+**1.6.0**
+
+* Added SCTE-35 parsing with `M3u8::Scte35` for `splice_info_section`
+  payloads, including `splice_null` (0x00), `splice_insert` (0x05),
+  `time_signal` (0x06), and descriptor loop parsing.
+* Added `DateRangeItem` SCTE-35 convenience methods:
+  `scte35_cmd_info`, `scte35_out_info`, and `scte35_in_info`.
+* Added parsing support for SCTE-35 segmentation descriptors
+  (`segmentation_descriptor`, tag 0x02 with `CUEI` identifier).
+* Added `M3u8::Scte35::ParseError` for malformed SCTE-35 payloads.
+* Documented SCTE-35 usage and parsed fields in README.
+
+***
+
 **1.5.0**
 
 * Added `Playlist#freeze` for deep-freezing playlists, items, nested objects, and playlist-level objects. `Playlist.build` and `Playlist.read` now return frozen playlists. `Playlist.new` remains mutable until `freeze` is called explicitly.

--- a/lib/m3u8/version.rb
+++ b/lib/m3u8/version.rb
@@ -2,5 +2,5 @@
 
 # M3u8 provides parsing, generation, and validation of m3u8 playlists
 module M3u8
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
Prepare the next release for the SCTE-35 parsing work already\nmerged on this branch.\n\nDocument the new release entry so consumers can quickly identify\nnew parsing capabilities and error-handling behavior.