### PR TITLE
Add CUE attribute to DateRangeItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Insert a timed metadata date range:
 ```ruby
 item = M3u8::DateRangeItem.new(
   id: 'ad-break-1', start_date: '2024-06-01T12:00:00Z',
-  planned_duration: 30.0,
+  planned_duration: 30.0, cue: 'PRE',
   client_attributes: { 'X-AD-ID' => '"foo"' }
 )
 playlist.items << item

--- a/lib/m3u8/date_range_item.rb
+++ b/lib/m3u8/date_range_item.rb
@@ -7,7 +7,7 @@ module M3u8
 
     attr_accessor :id, :class_name, :start_date, :end_date, :duration,
                   :planned_duration, :scte35_cmd, :scte35_out, :scte35_in,
-                  :end_on_next, :client_attributes
+                  :cue, :end_on_next, :client_attributes
 
     def initialize(options = {})
       options.each do |key, value|
@@ -26,6 +26,7 @@ module M3u8
       @scte35_cmd = attributes['SCTE35-CMD']
       @scte35_out = attributes['SCTE35-OUT']
       @scte35_in = attributes['SCTE35-IN']
+      @cue = attributes['CUE']
       @end_on_next = attributes.key?('END-ON-NEXT')
       @client_attributes = parse_client_attributes(attributes)
     end
@@ -59,6 +60,7 @@ module M3u8
        scte35_cmd_format,
        scte35_out_format,
        scte35_in_format,
+       cue_format,
        end_on_next_format].compact.join(',')
     end
 
@@ -123,6 +125,12 @@ module M3u8
       return if scte35_in.nil?
 
       "SCTE35-IN=#{scte35_in}"
+    end
+
+    def cue_format
+      return if cue.nil?
+
+      %(CUE="#{cue}")
     end
 
     def end_on_next_format

--- a/spec/lib/m3u8/date_range_item_spec.rb
+++ b/spec/lib/m3u8/date_range_item_spec.rb
@@ -11,7 +11,8 @@ describe M3u8::DateRangeItem do
                   planned_duration: 59.993,
                   scte35_out: '0xFC002F0000000000FF0',
                   scte35_in: '0xFC002F0000000000FF1',
-                  scte35_cmd: '0xFC002F0000000000FF2', end_on_next: true,
+                  scte35_cmd: '0xFC002F0000000000FF2',
+                  cue: 'PRE', end_on_next: true,
                   client_attributes: { 'X-CUSTOM' => 45.3 } }
       item = described_class.new(options)
 
@@ -24,6 +25,7 @@ describe M3u8::DateRangeItem do
       expect(item.scte35_out).to eq('0xFC002F0000000000FF0')
       expect(item.scte35_in).to eq('0xFC002F0000000000FF1')
       expect(item.scte35_cmd).to eq('0xFC002F0000000000FF2')
+      expect(item.cue).to eq('PRE')
       expect(item.end_on_next).to be true
       expect(item.client_attributes.empty?).to be false
       expect(item.client_attributes['X-CUSTOM']).to eq(45.3)
@@ -39,6 +41,7 @@ describe M3u8::DateRangeItem do
              'PLANNED-DURATION=59.993,SCTE35-OUT=0xFC002F0000000000FF0,' \
              'SCTE35-IN=0xFC002F0000000000FF1,' \
              'SCTE35-CMD=0xFC002F0000000000FF2,' \
+             'CUE="PRE",' \
              'END-ON-NEXT=YES'
       item.parse(line)
 
@@ -51,6 +54,7 @@ describe M3u8::DateRangeItem do
       expect(item.scte35_out).to eq('0xFC002F0000000000FF0')
       expect(item.scte35_in).to eq('0xFC002F0000000000FF1')
       expect(item.scte35_cmd).to eq('0xFC002F0000000000FF2')
+      expect(item.cue).to eq('PRE')
       expect(item.end_on_next).to be true
       expect(item.client_attributes.empty?).to be true
     end
@@ -93,7 +97,8 @@ describe M3u8::DateRangeItem do
                   planned_duration: 59.993,
                   scte35_out: '0xFC002F0000000000FF0',
                   scte35_in: '0xFC002F0000000000FF1',
-                  scte35_cmd: '0xFC002F0000000000FF2', end_on_next: true,
+                  scte35_cmd: '0xFC002F0000000000FF2',
+                  cue: 'POST,ONCE', end_on_next: true,
                   client_attributes: { 'X-CUSTOM' => 45.3,
                                        'X-CUSTOM-TEXT' => 'test_value' } }
       item = described_class.new(options)
@@ -107,6 +112,7 @@ describe M3u8::DateRangeItem do
                  'SCTE35-CMD=0xFC002F0000000000FF2,' \
                  'SCTE35-OUT=0xFC002F0000000000FF0,' \
                  'SCTE35-IN=0xFC002F0000000000FF1,' \
+                 'CUE="POST,ONCE",' \
                  'END-ON-NEXT=YES'
 
       expect(item.to_s).to eq(expected)


### PR DESCRIPTION
The EXT-X-DATERANGE tag gained a CUE attribute in HLS Protocol Version 12 (draft-pantos-hls-rfc8216bis). It is an enumerated-string-list used for HLS Interstitials — values like PRE, POST, ONCE tell players when/how to trigger interstitial content. Previously the library silently dropped this attribute since it is not an X- prefixed client attribute.