### PR TITLE
Remove HoundCI config and update project metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /coverage
 /pkg
 /tmp
-.Gemfile.lock
+Gemfile.lock
 .ruby-version

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,0 @@
-ruby:
-  enabled: true
-  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
   SuggestExtensions: false
   Exclude:

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Seth Deckard
+Copyright (c) 2014-2026 Seth Deckard
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ m3u8 provides easy generation and parsing of m3u8 playlists defined in [RFC 8216
 
 ## Requirements
 
-Ruby 3.0+
+Ruby 3.1+
 
 ## Installation
 

--- a/m3u8.gemspec
+++ b/m3u8.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'm3u8/version'
 
@@ -8,11 +7,11 @@ Gem::Specification.new do |spec|
   spec.version       = M3u8::VERSION
   spec.authors       = ['Seth Deckard']
   spec.email         = ['seth@deckard.me']
-  spec.summary       = %q{Generate and parse m3u8 playlists for HTTP Live Streaming (HLS).}
-  spec.description   = %q{Generate and parse m3u8 playlists for HTTP Live Streaming (HLS).}
+  spec.summary       = 'Generate and parse m3u8 playlists for HTTP Live Streaming (HLS).'
+  spec.description   = 'Generate and parse m3u8 playlists for HTTP Live Streaming (HLS).'
   spec.homepage      = 'https://github.com/sethdeckard/m3u8'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.files         = `git ls-files -z`.split("\x0")
                                         .grep_v(/\A(CLAUDE|AGENTS)\.md\z/)


### PR DESCRIPTION
Remove unused .hound.yml, update copyright years to 2014-2026, fix .gitignore typo, drop Ruby 3.0 and add Ruby 3.4 to CI matrix, and modernize gemspec.